### PR TITLE
Removes $DS_APP_ROOT env var.

### DIFF
--- a/group_vars/staging/app-environment.yml
+++ b/group_vars/staging/app-environment.yml
@@ -3,7 +3,6 @@
 
 app_environment:
   - { option: DS_ENVIRONMENT, value: stage }
-  - { option: DS_APP_ROOT, value: "{{ app_root }}" }
   - { option: DS_DB_MASTER_NAME, value: "{{ app_user }}" }
   - { option: DS_DB_MASTER_USER, value: "stage" }
   - { option: DS_DB_MASTER_HOST, value: "stage.c9ajz690mens.us-east-1.rds.amazonaws.com" }


### PR DESCRIPTION
On staging and prod actual builds happen outside of `$DS_APP_ROOT` folder so we don't want to hardcode its value and let `ds` script discover it by automatically.