### PR TITLE
Update roles.

### DIFF
--- a/roles/dosomething.base/meta/.galaxy_install_info
+++ b/roles/dosomething.base/meta/.galaxy_install_info
@@ -1,1 +1,1 @@
-{install_date: 'Tue May 19 18:47:55 2015', version: master}
+{install_date: 'Wed May 20 20:52:33 2015', version: master}

--- a/roles/dosomething.dosomething-dev/meta/.galaxy_install_info
+++ b/roles/dosomething.dosomething-dev/meta/.galaxy_install_info
@@ -1,1 +1,1 @@
-{install_date: 'Tue May 19 18:48:13 2015', version: master}
+{install_date: 'Wed May 20 20:52:47 2015', version: master}

--- a/roles/dosomething.dosomething/meta/.galaxy_install_info
+++ b/roles/dosomething.dosomething/meta/.galaxy_install_info
@@ -1,1 +1,1 @@
-{install_date: 'Tue May 19 18:48:09 2015', version: master}
+{install_date: 'Wed May 20 20:52:44 2015', version: master}

--- a/roles/dosomething.dosomething/templates/nginx/app.j2
+++ b/roles/dosomething.dosomething/templates/nginx/app.j2
@@ -49,7 +49,7 @@ server {
   ## Parse all .php file in the app directory
   location ~ \.php$ {
     fastcgi_split_path_info ^(.+\.php)(.*)$;
-    fastcgi_pass   unix:{{ php_fpm_socket }};
+    fastcgi_pass   {{ php_fpm_listen }};
     fastcgi_index  index.php;
     include fastcgi_params;
 

--- a/roles/dosomething.redis/meta/.galaxy_install_info
+++ b/roles/dosomething.redis/meta/.galaxy_install_info
@@ -1,1 +1,1 @@
-{install_date: 'Tue May 19 18:48:06 2015', version: master}
+{install_date: 'Wed May 20 20:52:41 2015', version: master}

--- a/roles/dosomething.redis/tasks/main.yml
+++ b/roles/dosomething.redis/tasks/main.yml
@@ -4,7 +4,7 @@
   sudo: yes
   apt: name=redis-server state=latest
 
-- name: Setup redus
+- name: Setup Redis
   sudo: yes
   lineinfile: >
     dest=/etc/redis/redis.conf

--- a/roles/dosomething.search/meta/.galaxy_install_info
+++ b/roles/dosomething.search/meta/.galaxy_install_info
@@ -1,1 +1,1 @@
-{install_date: 'Tue May 19 18:48:02 2015', version: master}
+{install_date: 'Wed May 20 20:52:39 2015', version: master}

--- a/roles/dosomething.web/README.md
+++ b/roles/dosomething.web/README.md
@@ -53,12 +53,12 @@ php_fpm_settings:
   - { option: group,  value: "app" }
 ```
 
-#### FPM Socket
-A path to PHP-fpm socket.  
+#### FPM Listen
+A path to PHP-fpm socket or an address to bind server to.  
 Defaults to `/var/run/php5-fpm.sock`.
 
 ```yml
-php_fpm_socket: /var/run/application.sock
+php_fpm_listen: /var/run/php5-fpm.sock
 ```
 
 ### PHP Extensions

--- a/roles/dosomething.web/defaults/main.yml
+++ b/roles/dosomething.web/defaults/main.yml
@@ -7,7 +7,7 @@ composer_path: '/usr/local/bin'
 
 # PHP
 php_ini_settings: []
-php_fpm_socket: /var/run/php5-fpm.sock
+php_fpm_listen: 127.0.0.1:9000
 php_fpm_settings: []
 
 # PHP Extensions

--- a/roles/dosomething.web/handlers/main.yml
+++ b/roles/dosomething.web/handlers/main.yml
@@ -1,9 +1,13 @@
 ---
 # handlers file for web
 
+# Temporary. See issue
+# https://github.com/ansible/ansible-modules-core/issues/1170
+# When ansible is upgraded, restore the following command:
+# service: name=php5-fpm state=restarted
 - name: restart php-fpm
   sudo: yes
-  service: name=php5-fpm state=restarted
+  command: service php5-fpm restart
 
 - name: restart nginx
   sudo: yes

--- a/roles/dosomething.web/meta/.galaxy_install_info
+++ b/roles/dosomething.web/meta/.galaxy_install_info
@@ -1,1 +1,1 @@
-{install_date: 'Tue May 19 18:47:58 2015', version: master}
+{install_date: 'Wed May 20 20:52:36 2015', version: master}

--- a/roles/dosomething.web/tasks/web-server.yml
+++ b/roles/dosomething.web/tasks/web-server.yml
@@ -6,5 +6,5 @@
 
 - name: Nginx | Disable default vhost
   sudo: yes
-  file: path=/etc/nginx/sites-available/default state=absent
+  file: path=/etc/nginx/sites-enabled/default state=absent
   notify: restart nginx

--- a/roles/dosomething.web/vars/main.yml
+++ b/roles/dosomething.web/vars/main.yml
@@ -3,9 +3,8 @@
 
 # PHP
 php_fpm_defaults:
-  - { option: listen,                 value: "{{ php_fpm_socket }}" }
+  - { option: listen,                 value: "{{ php_fpm_listen }}" }
   - { option: listen.allowed_clients, value: "127.0.0.1" }
-  - { option: listen.mode,            value: "0600" }
 
 # PHP Extensions
 php_extensions_defaults:


### PR DESCRIPTION
- PHP FPM/Nginx communicate through TCP now, not Unix socket, see https://rtcamp.com/tutorials/php/fpm-sysctl-tweaking/
- PHP FPM restarts using `command` module, not `service`, see https://github.com/ansible/ansible-modules-core/issues/1170
