### PR TITLE
Remove $DS_DB_MASTER_NAME var on intl prod.

### DIFF
--- a/group_vars/international-production/app-environment.yml
+++ b/group_vars/international-production/app-environment.yml
@@ -3,7 +3,6 @@
 
 app_environment_variables:
   - { option: DS_ENVIRONMENT, value: "{{ app_environment }}" }
-  - { option: DS_DB_MASTER_NAME, value: "{{ app_user }}" }
   - { option: DS_DB_MASTER_USER, value: "dsintl" }
   - { option: DS_DB_MASTER_PASS, value: "{{ app_db_password }}" }
   - { option: DS_DB_MASTER_HOST, value: "drupal-intl.c9ajz690mens.us-east-1.rds.amazonaws.com" }


### PR DESCRIPTION
So it gets overriden by local DB setting.