### PR TITLE
Testing utilities: lock npm version.

### DIFF
--- a/roles/dosomething.dosomething-dev/tasks/testing-utilities.yml
+++ b/roles/dosomething.dosomething-dev/tasks/testing-utilities.yml
@@ -1,8 +1,10 @@
 ---
 
 - name: Install testing utilities using NPM
-  npm: name={{ item }} global=yes state=latest
+  npm: name={{ item.name }} version={{ item.version }} global=yes state=latest
   sudo: yes
   with_items:
-    - mocha-phantomjs
-    - casperjs
+    - name: mocha-phantomjs
+      version: 3.*
+    - name: casperjs
+      version: 1.*


### PR DESCRIPTION
Latest `mocha-phantomjs` version is `4.0.0-beta1`, which requires `phantomjs2@2.0.0`.
Phantomjs2 build fails with the following error:

```
msg: npm ERR! phantomjs2@2.0.0 install:********@2.0.0 install script.
npm ERR! This is most likely a problem with the phantomjs2 package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node install.js
npm ERR! You can get their info via:
npm ERR!     npm owner ls phantomjs2
npm ERR! There is likely additional logging output above.
```

So I decided to lock `mocha-phantomjs` on branch `3.*` and, just to be safe, I also locked casper on `1.*`.