### PR TITLE
Refactors ansible role dependencies managed with requirements.yml.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,15 @@
+# System
 *.DS_Store
 
-.vault.txt
-
+# Vagrant
 .vagrant
 package.box
 
+# Ansible
+## Vault
+.vault.txt
+
+## Roles
+### Ignore all roles except dosomething.*.
+roles/*
+!roles/dosomething.*

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,6 +14,10 @@ Vagrant.configure("2") do |config|
   # Hostname
   config.vm.hostname = "dev.dosomething.org"
 
+  config.vm.provision :host_shell do |host|
+    host.inline = 'ansible-galaxy install -r requirements.yml -p roles/ -f'
+  end
+
   config.vm.provision "ansible" do |ansible|
     ansible.verbose = :v
     ansible.playbook = "vagrant.yml"

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,9 +1,2 @@
 ---
-- src: dosomething.base
-- src: dosomething.web
-- src: dosomething.search
-- src: dosomething.redis
-- src: dosomething.dosomething
-- src: dosomething.dosomething-dev
-- src: dosomething.db
-- src: dosomething.vagrant
+- src: franklinkim.nodejs


### PR DESCRIPTION
#### What's this PR do?
- Changes `requirements.yml` to include only remote dependencies
- Changes `.gitignore` to ignore all roles, except own `dosomething.*` roles
- Makes vagrant automatically redownload ansible role dependencies to be compatible with Tower 2.2