### PR TITLE
Moves roles path to requirements.yml.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure("2") do |config|
   config.vm.hostname = "dev.dosomething.org"
 
   config.vm.provision :host_shell do |host|
-    host.inline = 'ansible-galaxy install -r requirements.yml -p roles/ -f'
+    host.inline = 'ansible-galaxy install -r requirements.yml -f'
   end
 
   config.vm.provision "ansible" do |ansible|

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,2 +1,3 @@
 ---
 - src: franklinkim.nodejs
+  path: roles/


### PR DESCRIPTION
Fix for https://tower.dosomething.org/#/jobs/395/stdout:
ERROR: cannot find role in /var/lib/awx/projects/_422__tower/roles/franklinkim.nodejs