### PR TITLE
Fixes ansible galaxy requirements installation for vagrant.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure("2") do |config|
   config.vm.hostname = "dev.dosomething.org"
 
   config.vm.provision :host_shell do |host|
-    host.inline = 'ansible-galaxy install -r roles/requirements.yml -f'
+    host.inline = 'ansible-galaxy install -r roles/requirements.yml -p roles/ -f'
   end
 
   config.vm.provision "ansible" do |ansible|


### PR DESCRIPTION
Fixes error:
```
ERROR: cannot find role in /Users/sergii/Development/tower/roles/franklinkim.nodejs or /Users/sergii/Development/tower/franklinkim.nodejs or /opt/local/etc/ansible/roles/franklinkim.nodejs
```