### PR TITLE
Runs composer auth task only when the token is defined.

### DIFF
--- a/roles/dosomething.dosomething/tasks/composer.yml
+++ b/roles/dosomething.dosomething/tasks/composer.yml
@@ -17,3 +17,6 @@
 - name: Composer | Setup GitHub access token
   remote_user: "{{ app_user }}"
   template: src=composer/auth.json.j2 dest=.composer/auth.json
+  when: >
+    app_composer_github_access_token is defined
+    and app_composer_github_access_token != ''


### PR DESCRIPTION
Fixes #77.