### PR TITLE
Adding error page directive to display app 404 page, not Nginx one.

### DIFF
--- a/roles/dosomething.phoenix/templates/nginx/app.j2
+++ b/roles/dosomething.phoenix/templates/nginx/app.j2
@@ -30,6 +30,9 @@ server {
   location / {
     # This is cool because no php is touched for static content
     try_files $uri @rewrite;
+    # This will direct Nginx 404's to the app, as it has a PHP extension, and will be handled
+    # by the php directive below.You can use any location that doesn't exist in your app to 
+    # generate a 404. Alternately, you can direct it to an actual 404 page if you have one.
     error_page 404 /leftathetrafficlight.php;
   }
 

--- a/roles/dosomething.phoenix/templates/nginx/app.j2
+++ b/roles/dosomething.phoenix/templates/nginx/app.j2
@@ -33,7 +33,7 @@ server {
     # This will direct Nginx 404's to the app, as it has a PHP extension, and will be handled
     # by the php directive below.You can use any location that doesn't exist in your app to 
     # generate a 404. Alternately, you can direct it to an actual 404 page if you have one.
-    error_page 404 /leftathetrafficlight.php;
+    error_page 404 = @rewrite;
   }
 
   location @rewrite {

--- a/roles/dosomething.phoenix/templates/nginx/app.j2
+++ b/roles/dosomething.phoenix/templates/nginx/app.j2
@@ -30,6 +30,7 @@ server {
   location / {
     # This is cool because no php is touched for static content
     try_files $uri @rewrite;
+    error_page 404 /leftathetrafficlight.php;
   }
 
   location @rewrite {


### PR DESCRIPTION
#### What's this PR do?
Directs Nginx to send 404 errors to be parsed by Drupal instead of Nginx itself.

#### Where should the reviewer start?
I am waiting for you, Vizzini! You told me to go back to the beginning!

#### How should this be manually tested?
Already tested manually in staging and thor.

#### Any background context you want to provide?
We saw 404 Nginx errors on certain pages.

#### What are the relevant tickets?
https://github.com/DoSomething/phoenix/issues/5298
