### PR TITLE
Using "command" module to install apt HHVM key.

### DIFF
--- a/roles/dosomething.hhvm/tasks/main.yml
+++ b/roles/dosomething.hhvm/tasks/main.yml
@@ -4,7 +4,7 @@
 
 - name: Add HHVM Apt Key
   become: yes
-  apt_key: keyserver=keyserver.ubuntu.com:80 id=0x5a16e7281be7a449
+  command: apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0x5a16e7281be7a449
 
 - name: Add HHVM Apt Repo
   become: yes


### PR DESCRIPTION
The apt_key repository keeps returning not found.
Manually run on this one of the boxes and it's working.