### PR TITLE
Add secure site for hosting forge assets.

### DIFF
--- a/roles/dosomething.nginx-static/tasks/main.yml
+++ b/roles/dosomething.nginx-static/tasks/main.yml
@@ -1,6 +1,9 @@
-- name: Create Static Files Dir
+- name: Create Static Files Directories
   become: yes
-  file: path=/var/www/static state=directory owner=nginx group=nginx mode=755
+  file: path={{ item }} state=directory owner=nginx group=nginx mode=755
+  with_items:
+    - /var/www/static
+    - /var/www/forge
 
 - name: Remove Existing Default Sites Files
   become: yes

--- a/roles/dosomething.nginx-static/templates/nginx.conf.j2
+++ b/roles/dosomething.nginx-static/templates/nginx.conf.j2
@@ -23,3 +23,16 @@ server {
   }
 
 }
+
+server {
+   listen 80;
+
+   server_name adamantium.dosomething.org;
+
+   root /var/www/forge/dist;
+
+   location / {
+      try_files $uri $uri/ = 404;
+   }
+  
+}


### PR DESCRIPTION
#### What's this PR do?
Adds config to static Nginx hosting servers to host secure version of forge.ds.org.

#### Where should the reviewer start?
dosomething.nginx-static/templates/nginx.conf.j2 file.

#### How should this be manually tested?
We're doing it live!

#### Any background context you want to provide?
We need to host a secure version of our forge assets to enable secure form hosting. Originally made for help.dosomething.org launch.

