### PR TITLE
Fixes Ansible 2.0 compatibility.

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,1 @@
 [defaults]
-executable = /bin/sh -l

--- a/roles/dosomething.mb-php/tasks/apps.yml
+++ b/roles/dosomething.mb-php/tasks/apps.yml
@@ -6,7 +6,6 @@
     path={{ mb_php_root }}
     state=directory
     owner={{ app_user }}
-  sudo: yes
 
 - name: MB PHP | Ensure log folder
   sudo: yes
@@ -14,7 +13,6 @@
     path={{ mb_php_log_path }}
     state=directory
     owner={{ app_user }}
-  sudo: yes
 
 - name: MB PHP | Checkout configuration
   remote_user: "{{ app_user }}"

--- a/roles/dosomething.nodejs-server/defaults/main.yml
+++ b/roles/dosomething.nodejs-server/defaults/main.yml
@@ -2,7 +2,4 @@
 # defaults file for nodejs
 
 # PM2
-pm2_startup: ubuntu
-pm2_service_enabled: yes
-pm2_service_state: stopped
 pm2_version: 1.0.*

--- a/roles/dosomething.nodejs-server/defaults/main.yml
+++ b/roles/dosomething.nodejs-server/defaults/main.yml
@@ -4,5 +4,5 @@
 # PM2
 pm2_startup: ubuntu
 pm2_service_enabled: yes
-pm2_service_state: started
-version: 0.14.*
+pm2_service_state: stopped
+pm2_version: 1.0.*

--- a/roles/dosomething.nodejs-server/meta/main.yml
+++ b/roles/dosomething.nodejs-server/meta/main.yml
@@ -13,4 +13,4 @@ galaxy_info:
   - system
 dependencies:
   - { role: "dosomething.nodejs", sudo: yes }
-  - { role: "franklinkim.pm2", sudo: yes }
+  - { role: "weareinteractive.pm2", sudo: yes }

--- a/roles/dosomething.nodejs-server/meta/main.yml
+++ b/roles/dosomething.nodejs-server/meta/main.yml
@@ -13,4 +13,3 @@ galaxy_info:
   - system
 dependencies:
   - { role: "dosomething.nodejs", sudo: yes }
-  - { role: "weareinteractive.pm2", sudo: yes }

--- a/roles/dosomething.nodejs-server/requirements.yml
+++ b/roles/dosomething.nodejs-server/requirements.yml
@@ -1,1 +1,2 @@
-- src: franklinkim.pm2
+---
+- src: weareinteractive.pm2

--- a/roles/dosomething.nodejs-server/requirements.yml
+++ b/roles/dosomething.nodejs-server/requirements.yml
@@ -1,2 +1,0 @@
----
-- src: weareinteractive.pm2

--- a/roles/dosomething.nodejs-server/tasks/main.yml
+++ b/roles/dosomething.nodejs-server/tasks/main.yml
@@ -1,1 +1,20 @@
 ---
+
+- name: Node.js server | Install PM2
+  become: yes
+  npm:
+    name: pm2
+    global: yes
+    version: "{{ pm2_version | default(omit) }}"
+
+- name:  Node.js server | Installing PM2 startup script
+  become: yes
+  command: >
+    pm2 startup ubuntu
+
+- name: Node.js server | Configuring service
+  become: yes
+  service:
+    name: "pm2-init.sh"
+    state: "stopped"
+    enabled: "yes"

--- a/roles/dosomething.phoenix-dev/tasks/testing-utilities.yml
+++ b/roles/dosomething.phoenix-dev/tasks/testing-utilities.yml
@@ -1,7 +1,9 @@
 ---
 
 - name: Install testing utilities using NPM
-  npm: name={{ item.name }} version={{ item.version }} global=yes state=latest
+  # Changed from latest to present due to bug, see
+  # https://github.com/ansible/ansible-modules-extras/issues/1375
+  npm: name={{ item.name }} version={{ item.version }} global=yes state=present
   sudo: yes
   with_items:
     - name: mocha-phantomjs

--- a/roles/dosomething.phoenix/tasks/npm.yml
+++ b/roles/dosomething.phoenix/tasks/npm.yml
@@ -1,7 +1,9 @@
 ---
 
 - name: DoSomething App | Install global NPM libraries
-  npm: name={{ item }} global=yes state=latest
+  # Changed from latest to present due to bug, see
+  # https://github.com/ansible/ansible-modules-extras/issues/1375
+  npm: name={{ item }} global=yes state=present
   sudo: yes
   with_items:
     - grunt-cli

--- a/roles/dosomething.php/tasks/php.yml
+++ b/roles/dosomething.php/tasks/php.yml
@@ -13,7 +13,7 @@
 - name: PHP | Install extensions
   apt: name={{ item }} state=latest
   sudo: yes
-  with_items: php_extensions_defaults + php_extensions
+  with_items: "{{ php_extensions_defaults }} + {{ php_extensions }}"
   notify: restart php-fpm
 
 - name: PHP | Alter php.ini
@@ -34,5 +34,5 @@
     section=www
     option={{ item.option }}
     value={{ item.value }}
-  with_items: php_fpm_defaults + php_fpm_settings
+  with_items: "{{ php_fpm_defaults }} + {{ php_fpm_settings }}"
   notify: restart php-fpm

--- a/roles/dosomething.rabbitmq/tasks/install.yml
+++ b/roles/dosomething.rabbitmq/tasks/install.yml
@@ -1,14 +1,14 @@
 ---
 
-- name: RabbitMQ | Add rabbitmq.com APT Repository
-  sudo: yes
-  apt_repository: repo="deb http://www.rabbitmq.com/debian/ testing main"
-
 - name: RabbitMQ | Add rabbitmq.com public key
   sudo: yes
   apt_key: >
-    url=http://www.rabbitmq.com/rabbitmq-signing-key-public.asc
+    url=https://www.rabbitmq.com/rabbitmq-signing-key-public.asc
     id=056E8E56
+
+- name: RabbitMQ | Add rabbitmq.com APT Repository
+  sudo: yes
+  apt_repository: repo="deb http://www.rabbitmq.com/debian/ testing main"
 
 - name: RabbitMQ | Install
   sudo: yes

--- a/roles/dosomething.search/tasks/main.yml
+++ b/roles/dosomething.search/tasks/main.yml
@@ -2,9 +2,7 @@
 
 - name: Update Java
   sudo: yes
-  apt: name=java7-jdk state=latest
-  register: java_update
-  changed_when: '"is already the newest version" not in java_update.stdout'
+  apt: name=openjdk-7-jdk state=latest
 
 - name: Check if Solr installed
   stat: path=/opt/solr-{{ solr_version }}

--- a/roles/dosomething.web/tasks/php.yml
+++ b/roles/dosomething.web/tasks/php.yml
@@ -11,7 +11,7 @@
 - name: PHP | Install extensions
   apt: name={{ item }} state=latest
   sudo: yes
-  with_items: php_extensions_defaults + php_extensions
+  with_items: "{{ php_extensions_defaults }} + {{ php_extensions }}"
   notify: restart php-fpm
 
 - name: PHP | Alter php.ini
@@ -32,5 +32,5 @@
     section=www
     option={{ item.option }}
     value={{ item.value }}
-  with_items: php_fpm_defaults + php_fpm_settings
+  with_items: "{{ php_fpm_defaults }} + {{ php_fpm_settings }}"
   notify: restart php-fpm

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -1,2 +1,2 @@
 ---
-- src: franklinkim.pm2
+- src: weareinteractive.pm2

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -1,2 +1,2 @@
 ---
-- src: weareinteractive.pm2
+


### PR DESCRIPTION
A list of v2.0-related changes:
- `ansible.cfg` doesn't support executable with arguments anymore, but with 2.0 we don't need it
- `apt_key` MUST be declared before `apt_repository`
- `with_items` only support list merge using string substituion

Ubuntu-related changes:
- `ubuntu/trusty64` is updated to `20160311.0.0`
- `java7-jdk` package doesn't exist. It was succeeded by `openjdk-7-jdk`.

Other changes:
- `franklinkim.pm2` was renamed to `weareinteractive.pm2`
- `weareinteractive.pm2` dependency is replaced with our own simple implementation because of the incompatibility