### PR TITLE
Replaces sudo privilege escalation command with become.

### DIFF
--- a/production.yml
+++ b/production.yml
@@ -16,10 +16,10 @@
   hosts: tag_Role_Drupal_WebApp
   tasks:
   - name: Install nfs-common
-    sudo: yes
+    become: yes
     apt: name=nfs-common state=latest
   - name: Mount NFS
-    sudo: yes
+    become: yes
     mount: >
       name=/var/www/www.dosomething.org/shared/files
       src='10.100.20.6:/drupal-static-files'

--- a/roles/dosomething.base/handlers/main.yml
+++ b/roles/dosomething.base/handlers/main.yml
@@ -2,5 +2,5 @@
 # handlers file for ds-base
 
 - name: restart ntp
-  sudo: yes
+  become: yes
   service: name=ntp state=restarted

--- a/roles/dosomething.base/tasks/configure-system.yml
+++ b/roles/dosomething.base/tasks/configure-system.yml
@@ -6,12 +6,12 @@
   changed_when: False
 
 - name: System | Set timezone
-  sudo: yes
+  become: yes
   command: timedatectl set-timezone {{ timezone }}
   when: '"{{ timezone }}" not in get_timezone.stdout'
 
 - name: System | Ensure locale exists
-  sudo: yes
+  become: yes
   locale_gen: name={{ locale }} state=present
 
 - name: System | Check current locale
@@ -20,13 +20,13 @@
   changed_when: False
 
 - name: System | Set locale
-  sudo: yes
+  become: yes
   command: update-locale LC_ALL={{ locale }} LANG={{ locale }}
   when: '"LC_ALL={{ locale }}" not in get_locale.stdout'
 
 # https://www.percona.com/blog/2014/04/28/oom-relation-vm-swappiness0-new-kernel/
 - name: System | Set vm.swappiness
-  sudo: yes
+  become: yes
   sysctl: >
     name="vm.swappiness"
     value=1

--- a/roles/dosomething.base/tasks/install-common-tools.yml
+++ b/roles/dosomething.base/tasks/install-common-tools.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Install Common Tools
-  sudo: yes
+  become: yes
   apt: name={{ item }} state=latest
   with_items:
     - ntp

--- a/roles/dosomething.base/tasks/setup-devops-users.yml
+++ b/roles/dosomething.base/tasks/setup-devops-users.yml
@@ -1,14 +1,14 @@
 ---
 
 - name: Create DevOps Users
-  sudo: yes
+  become: yes
   user: >
     name={{ item }}
     shell=/bin/bash
   with_items: devops_users
 
 - name: SSH | Install public keys
-  sudo: yes
+  become: yes
   authorized_key: >
     user={{ item }}
     key="{{ lookup('file', 'files/devops_users/' + item + '-authorized_keys') }}"
@@ -17,7 +17,7 @@
     - "{{ devops_users }}"
 
 - name: Setup Sudoers for DevOps Users
-  sudo: yes
+  become: yes
   template: src=sudoers/devops_user.j2 dest=/etc/sudoers.d/{{ item }}_devops
   with_items:
     - "{{ devops_users }}"

--- a/roles/dosomething.base/tasks/setup-ntp.yml
+++ b/roles/dosomething.base/tasks/setup-ntp.yml
@@ -1,12 +1,12 @@
 ---
 
 - name: NTP | Check configuration cleanup lock
-  sudo: yes
+  become: yes
   stat: path=/etc/ntp.conf.lock
   register: ntp_lock
 
 - name: NTP | Cleanup configuration from default servers
-  sudo: yes
+  become: yes
   lineinfile: >
     dest=/etc/ntp.conf
     regexp=^server
@@ -16,12 +16,12 @@
   register: ntp_conf_cleaned
 
 - name: NTP | Lock configuration cleanup
-  sudo: yes
+  become: yes
   file: path=/etc/ntp.conf.lock state=touch
   when: ntp_conf_cleaned.changed
 
 - name: NTP | Configure provided NTP servers
-  sudo: yes
+  become: yes
   lineinfile: >
     dest=/etc/ntp.conf
     line="server {{ item }}"

--- a/roles/dosomething.base/tasks/setup-user.yml
+++ b/roles/dosomething.base/tasks/setup-user.yml
@@ -1,21 +1,21 @@
 ---
 
 - name: Create the app user
-  sudo: yes
+  become: yes
   user: >
     name={{ app_user }}
     password={{ app_user_password }}
     shell=/bin/bash
 
 - name: SSH | Install public keys
-  sudo: yes
+  become: yes
   authorized_key: >
     user={{ app_user }}
     key="{{ lookup('file', 'files/app_user/ssh/authorized_keys') }}"
     exclusive=yes
 
 - name: Setup sudoers for the app user
-  sudo: yes
+  become: yes
   template: src=sudoers/app_user.j2 dest=/etc/sudoers.d/{{ app_user }}
 
 - name: SSH | Populate known hosts

--- a/roles/dosomething.base/tasks/update-system.yml
+++ b/roles/dosomething.base/tasks/update-system.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: System | Safe Upgrade
-  sudo: yes
+  become: yes
   apt: >
     upgrade=safe
     state=latest
@@ -11,6 +11,6 @@
   register: apt_upgrade
 
 - name: System | Auto Remove Leaf Packages
-  sudo: yes
+  become: yes
   command: apt-get -y autoremove
   when: '"Use ''apt-get autoremove'' to remove them" in apt_upgrade.stdout'

--- a/roles/dosomething.db/handlers/main.yml
+++ b/roles/dosomething.db/handlers/main.yml
@@ -2,5 +2,5 @@
 # handlers file for db
 
 - name: restart mysql
-  sudo: yes
+  become: yes
   service: name=mysql state=restarted

--- a/roles/dosomething.db/tasks/main.yml
+++ b/roles/dosomething.db/tasks/main.yml
@@ -2,10 +2,10 @@
 
 - name: Install MySQL Server
   apt: name=mysql-server-5.6 state=latest
-  sudo: yes
+  become: yes
 
 - name: Alter my.cnf
-  sudo: yes
+  become: yes
   ini_file: >
     dest=/etc/mysql/my.cnf
     section={{ item.section }}

--- a/roles/dosomething.mb-node/tasks/apps.yml
+++ b/roles/dosomething.mb-node/tasks/apps.yml
@@ -5,7 +5,7 @@
     path={{ mb_node_root }}
     state=directory
     owner={{ app_user }}
-  sudo: yes
+  become: yes
 
 - name: MB Node | Checkout Apps
   remote_user: "{{ app_user }}"

--- a/roles/dosomething.mb-node/tasks/install.yml
+++ b/roles/dosomething.mb-node/tasks/install.yml
@@ -2,5 +2,5 @@
 
 # Todo: move to own role or reuse galaxy role.
 - name: MB Node | Install Mongodb server
-  sudo: yes
+  become: yes
   apt: name=mongodb-server state=latest

--- a/roles/dosomething.mb-php/tasks/apps.yml
+++ b/roles/dosomething.mb-php/tasks/apps.yml
@@ -1,14 +1,14 @@
 ---
 
 - name: MB PHP | Ensure app root folder
-  sudo: yes
+  become: yes
   file: >
     path={{ mb_php_root }}
     state=directory
     owner={{ app_user }}
 
 - name: MB PHP | Ensure log folder
-  sudo: yes
+  become: yes
   file: >
     path={{ mb_php_log_path }}
     state=directory
@@ -43,7 +43,7 @@
   when: item.composer is not defined or item.composer
 
 - name: MB PHP | Configure Apps
-  sudo: yes
+  become: yes
   file: >
     src={{ mb_php_config_path }}
     dest={{ mb_php_root }}/{{ item.name }}/{{ mb_php_config_name }}
@@ -53,7 +53,7 @@
   with_items: mb_php_apps
 
 - name: MB PHP | Install App Startup Sripts
-  sudo: yes
+  become: yes
   template: >
     src={{ item.name }}/init.conf.j2
     dest=/etc/init/{{ item.name }}.conf
@@ -61,7 +61,7 @@
   when: item.init is not defined or item.init
 
 - name: MB PHP | Start apps
-  sudo: yes
+  become: yes
   service: name={{ item.name }} state=started
   with_items: mb_php_apps
   when: item.init is not defined or item.init

--- a/roles/dosomething.nodejs-server/meta/main.yml
+++ b/roles/dosomething.nodejs-server/meta/main.yml
@@ -12,4 +12,4 @@ galaxy_info:
   categories:
   - system
 dependencies:
-  - { role: "dosomething.nodejs", sudo: yes }
+  - { role: "dosomething.nodejs", become: yes }

--- a/roles/dosomething.nodejs/tasks/install.yml
+++ b/roles/dosomething.nodejs/tasks/install.yml
@@ -1,16 +1,16 @@
 ---
 
 - name: Node.js | Adding APT key
-  sudo: yes
+  become: yes
   apt_key: >
     url=https://deb.nodesource.com/gpgkey/nodesource.gpg.key
     id=68576280
 
 - name: Node.js | Add Repo
-  sudo: yes
+  become: yes
   apt_repository: >
     repo="deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
 
 - name: Node.js | Install
-  sudo: yes
+  become: yes
   apt: name=nodejs state=latest

--- a/roles/dosomething.phoenix-dev/tasks/testing-utilities.yml
+++ b/roles/dosomething.phoenix-dev/tasks/testing-utilities.yml
@@ -4,7 +4,7 @@
   # Changed from latest to present due to bug, see
   # https://github.com/ansible/ansible-modules-extras/issues/1375
   npm: name={{ item.name }} version={{ item.version }} global=yes state=present
-  sudo: yes
+  become: yes
   with_items:
     - name: mocha-phantomjs
       version: 3.*

--- a/roles/dosomething.phoenix-dev/tasks/xdebug.yml
+++ b/roles/dosomething.phoenix-dev/tasks/xdebug.yml
@@ -1,11 +1,11 @@
 ---
 
 - name: Xdebug | Install
-  sudo: yes
+  become: yes
   apt: name=php5-xdebug state=latest
 
 - name: Xdebug | Setup
-  sudo: yes
+  become: yes
   lineinfile: >
     dest=/etc/php5/fpm/conf.d/20-xdebug.ini
     line={{ item }}

--- a/roles/dosomething.phoenix/tasks/app-shared.yml
+++ b/roles/dosomething.phoenix/tasks/app-shared.yml
@@ -6,7 +6,7 @@
     state=directory
     owner={{ app_user }}
     follow=yes
-  sudo: yes
+  become: yes
 
 - name: Install status.php
   remote_user: "{{ app_user }}"

--- a/roles/dosomething.phoenix/tasks/app.yml
+++ b/roles/dosomething.phoenix/tasks/app.yml
@@ -6,7 +6,7 @@
     state=directory
     owner={{ app_user }}
     follow=yes
-  sudo: yes
+  become: yes
 
 - name: Make app scripts available $PATH
   remote_user: "{{ app_user }}"

--- a/roles/dosomething.phoenix/tasks/configure-env.yml
+++ b/roles/dosomething.phoenix/tasks/configure-env.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Environment | Setup PHP Environment
-  sudo: yes
+  become: yes
   ini_file: >
     dest=/etc/php5/fpm/pool.d/www.conf
     section=www
@@ -11,7 +11,7 @@
   notify: restart php-fpm
 
 - name: Environment | Setup Shell Environment
-  sudo: yes
+  become: yes
   lineinfile:
     create=yes
     dest=/etc/profile.d/{{ app_user }}.sh

--- a/roles/dosomething.phoenix/tasks/configure-ssl.yml
+++ b/roles/dosomething.phoenix/tasks/configure-ssl.yml
@@ -15,7 +15,7 @@
     - "{{ app_host }}.key"
   notify: reload nginx
 
-# A snippet to remind how to generate seld signed cert.
+# A snippet to remind how to generate self signed cert.
 # - name: SSL | Create self signed cert
 #   become: yes
 #   command: >

--- a/roles/dosomething.phoenix/tasks/configure-ssl.yml
+++ b/roles/dosomething.phoenix/tasks/configure-ssl.yml
@@ -1,11 +1,11 @@
 ---
 
 - name: SSL | Create directory
-  sudo: yes
+  become: yes
   file: path=/etc/ssl/{{ app_user }} state=directory
 
 - name: SSL | Install certificates
-  sudo: yes
+  become: yes
   copy: >
     src=files/ssl/{{ item }}
     dest=/etc/ssl/{{ app_user }}/{{ item }}
@@ -17,7 +17,7 @@
 
 # A snippet to remind how to generate seld signed cert.
 # - name: SSL | Create self signed cert
-#   sudo: yes
+#   become: yes
 #   command: >
 #     openssl req -new -nodes -x509
 #     -extensions v3_ca

--- a/roles/dosomething.phoenix/tasks/configure-vhost.yml
+++ b/roles/dosomething.phoenix/tasks/configure-vhost.yml
@@ -1,12 +1,12 @@
 ---
 
 - name: Vhost | Install app vhost configuration file
-  sudo: yes
+  become: yes
   template: src=nginx/app.j2 dest=/etc/nginx/sites-available/{{ app_user }}
   notify: restart nginx
 
 - name: Vhost | Enable app vhost
-  sudo: yes
+  become: yes
   file: >
     src=/etc/nginx/sites-available/{{ app_user }}
     dest=/etc/nginx/sites-enabled/{{ app_user }}

--- a/roles/dosomething.phoenix/tasks/npm.yml
+++ b/roles/dosomething.phoenix/tasks/npm.yml
@@ -4,7 +4,7 @@
   # Changed from latest to present due to bug, see
   # https://github.com/ansible/ansible-modules-extras/issues/1375
   npm: name={{ item }} global=yes state=present
-  sudo: yes
+  become: yes
   with_items:
     - grunt-cli
     - bower

--- a/roles/dosomething.phoenix/tasks/utilities.yml
+++ b/roles/dosomething.phoenix/tasks/utilities.yml
@@ -2,7 +2,7 @@
 
 - name: Install software utilities
   apt: name={{ item }} state=latest
-  sudo: yes
+  become: yes
   with_items:
     - mysql-client-5.6
     - imagemagick

--- a/roles/dosomething.php/handlers/main.yml
+++ b/roles/dosomething.php/handlers/main.yml
@@ -6,9 +6,9 @@
 # When ansible is upgraded, restore the following command:
 # service: name=php5-fpm state=restarted
 - name: restart php-fpm
-  sudo: yes
+  become: yes
   command: service php5-fpm restart
 
 - name: restart newrelic-sysmond
-  sudo: yes
+  become: yes
   service: name=newrelic-sysmond state=restarted

--- a/roles/dosomething.php/tasks/php-composer.yml
+++ b/roles/dosomething.php/tasks/php-composer.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Install Composer
-  sudo: yes
+  become: yes
   shell: >
     curl -sS https://getcomposer.org/installer | php --
     --install-dir={{ composer_path }}
@@ -10,7 +10,7 @@
     creates: "{{ composer_path }}/composer"
 
 - name: Update Composer
-  sudo: yes
+  become: yes
   shell: composer self-update
   register: composer_update
   changed_when: '"You are already using composer" not in composer_update.stderr'

--- a/roles/dosomething.php/tasks/php.yml
+++ b/roles/dosomething.php/tasks/php.yml
@@ -2,7 +2,7 @@
 
 - name: PHP | Install PHP
   apt: name={{ item }} state=latest
-  sudo: yes
+  become: yes
   with_items:
     - php5
     - php5-fpm
@@ -12,12 +12,12 @@
 
 - name: PHP | Install extensions
   apt: name={{ item }} state=latest
-  sudo: yes
+  become: yes
   with_items: "{{ php_extensions_defaults }} + {{ php_extensions }}"
   notify: restart php-fpm
 
 - name: PHP | Alter php.ini
-  sudo: yes
+  become: yes
   ini_file: >
     dest=/etc/php5/fpm/php.ini
     section={{ item.section }}
@@ -28,7 +28,7 @@
   notify: restart php-fpm
 
 - name: PHP | Setup FPM pool
-  sudo: yes
+  become: yes
   ini_file: >
     dest=/etc/php5/fpm/pool.d/www.conf
     section=www

--- a/roles/dosomething.rabbitmq/handlers/main.yml
+++ b/roles/dosomething.rabbitmq/handlers/main.yml
@@ -2,9 +2,9 @@
 # handlers file for rabbitmq
 
 - name: restart rabbitmq-server
-  sudo: yes
+  become: yes
   service: name=rabbitmq-server state=restarted
 
 - name: reload rabbitmq-server
-  sudo: yes
+  become: yes
   service: name=rabbitmq-server state=reloaded

--- a/roles/dosomething.rabbitmq/tasks/configure.yml
+++ b/roles/dosomething.rabbitmq/tasks/configure.yml
@@ -1,27 +1,27 @@
 ---
 
 - name: RabbitMQ | Configure /etc/default/rabbitmq-server
-  sudo: yes
+  become: yes
   template: >
     src=etc/default/rabbitmq-server.j2
     dest=/etc/default/rabbitmq-server
   notify: reload rabbitmq-server
 
 - name: RabbitMQ | Remove guest user
-  sudo: yes
+  become: yes
   rabbitmq_user: user=guest state=absent
 
 - name: RabbitMQ | Cleanup default vhosts
-  sudo: yes
+  become: yes
   rabbitmq_vhost: name=/ state=absent
 
 - name: RabbitMQ | Create vhosts
-  sudo: yes
+  become: yes
   rabbitmq_vhost: name="{{ item }}"
   with_items: rabbitmq_vhosts
 
 - name: RabbitMQ | Create users
-  sudo: yes
+  become: yes
   rabbitmq_user:
     user:           "{{ item.0.user }}"
     password:       "{{ item.0.password }}"

--- a/roles/dosomething.rabbitmq/tasks/install.yml
+++ b/roles/dosomething.rabbitmq/tasks/install.yml
@@ -1,21 +1,21 @@
 ---
 
 - name: RabbitMQ | Add rabbitmq.com public key
-  sudo: yes
+  become: yes
   apt_key: >
     url=https://www.rabbitmq.com/rabbitmq-signing-key-public.asc
     id=056E8E56
 
 - name: RabbitMQ | Add rabbitmq.com APT Repository
-  sudo: yes
+  become: yes
   apt_repository: repo="deb http://www.rabbitmq.com/debian/ testing main"
 
 - name: RabbitMQ | Install
-  sudo: yes
+  become: yes
   apt: name=rabbitmq-server state=latest force=yes
 
 - name: RabbitMQ | Install plugins
-  sudo: yes
+  become: yes
   rabbitmq_plugin: names="{{ item }}"
   with_items: rabbitmq_plugins
   notify: reload rabbitmq-server

--- a/roles/dosomething.redis/handlers/main.yml
+++ b/roles/dosomething.redis/handlers/main.yml
@@ -2,5 +2,5 @@
 # handlers file for redis
 
 - name: restart redis-server
-  sudo: yes
+  become: yes
   service: name=redis-server state=restarted

--- a/roles/dosomething.redis/tasks/main.yml
+++ b/roles/dosomething.redis/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 
 - name: Install Redis
-  sudo: yes
+  become: yes
   apt: name=redis-server state=latest
 
 - name: Setup Redis
-  sudo: yes
+  become: yes
   lineinfile: >
     dest=/etc/redis/redis.conf
     regexp="{{ item.regexp }}"

--- a/roles/dosomething.search/handlers/main.yml
+++ b/roles/dosomething.search/handlers/main.yml
@@ -2,5 +2,5 @@
 # handlers file for search
 
 - name: restart solr
-  sudo: yes
+  become: yes
   service: name=solr state=restarted

--- a/roles/dosomething.search/tasks/main.yml
+++ b/roles/dosomething.search/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Update Java
-  sudo: yes
+  become: yes
   apt: name=openjdk-7-jdk state=latest
 
 - name: Check if Solr installed

--- a/roles/dosomething.search/tasks/solr-first-install.yml
+++ b/roles/dosomething.search/tasks/solr-first-install.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Create solr user
-  sudo: yes
+  become: yes
   user: >
     name=solr
     password=!
@@ -9,14 +9,14 @@
     createhome=no
 
 - name: Download
-  sudo: yes
+  become: yes
   get_url: >
     url={{ solr_mirror }}/{{ solr_version }}/solr-{{ solr_version }}.tgz
     dest=/opt/solr-{{ solr_version }}.tgz
     sha256sum={{ solr_sha256sum }}
 
 - name: Unpack
-  sudo: yes
+  become: yes
   unarchive: >
     src=/opt/solr-{{ solr_version }}.tgz
     dest=/opt/
@@ -24,7 +24,7 @@
     creates=/opt/solr-{{ solr_version }}
 
 - name: Set solr owner
-  sudo: yes
+  become: yes
   file: >
     path=/opt/solr-{{ solr_version }}
     owner=solr
@@ -33,7 +33,7 @@
     recurse=yes
 
 - name: Install Solr
-  sudo: yes
+  become: yes
   command: >
     /opt/solr-{{ solr_version }}/bin/install_solr_service.sh
     /opt/solr-{{ solr_version }}.tgz

--- a/roles/dosomething.search/tasks/solr-install-core.yml
+++ b/roles/dosomething.search/tasks/solr-install-core.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Checkout default solr core
-  sudo: yes
+  become: yes
   sudo_user: solr
   git: >
     repo={{ item.repo }}
@@ -10,7 +10,7 @@
   with_items: solr_cores
 
 - name: Enable default solr core
-  sudo: yes
+  become: yes
   sudo_user: solr
   command: >
     /opt/solr/bin/solr create_core

--- a/roles/dosomething.search/tasks/solr-install-core.yml
+++ b/roles/dosomething.search/tasks/solr-install-core.yml
@@ -2,7 +2,7 @@
 
 - name: Checkout default solr core
   become: yes
-  sudo_user: solr
+  become_user: solr
   git: >
     repo={{ item.repo }}
     version={{ item.version }}
@@ -11,7 +11,7 @@
 
 - name: Enable default solr core
   become: yes
-  sudo_user: solr
+  become_user: solr
   command: >
     /opt/solr/bin/solr create_core
     -c {{ item.name }}

--- a/roles/dosomething.vagrant/tasks/main.yml
+++ b/roles/dosomething.vagrant/tasks/main.yml
@@ -8,14 +8,14 @@
     mode="u=rwx,g=r,o=r"
 
 - name: Setup welcome message
-  sudo: yes
+  become: yes
   template: >
     src=etc/motd.j2
     dest=/etc/update-motd.d/60-dosomething
     mode="u=rwx,g=rx,o=rx"
 
 - name: Add custom vagrant hosts
-  sudo: yes
+  become: yes
   lineinfile: >
     dest=/etc/hosts
     line="{{ item }}"

--- a/roles/dosomething.web/handlers/main.yml
+++ b/roles/dosomething.web/handlers/main.yml
@@ -6,17 +6,17 @@
 # When ansible is upgraded, restore the following command:
 # service: name=php5-fpm state=restarted
 - name: restart php-fpm
-  sudo: yes
+  become: yes
   command: service php5-fpm restart
 
 - name: restart nginx
-  sudo: yes
+  become: yes
   service: name=nginx state=restarted
 
 - name: reload nginx
-  sudo: yes
+  become: yes
   service: name=nginx state=reloaded
 
 - name: restart newrelic-sysmond
-  sudo: yes
+  become: yes
   service: name=newrelic-sysmond state=restarted

--- a/roles/dosomething.web/tasks/php-composer.yml
+++ b/roles/dosomething.web/tasks/php-composer.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Install Composer
-  sudo: yes
+  become: yes
   shell: >
     curl -sS https://getcomposer.org/installer | php --
     --install-dir={{ composer_path }}
@@ -10,7 +10,7 @@
     creates: "{{ composer_path }}/composer"
 
 - name: Update Composer
-  sudo: yes
+  become: yes
   shell: composer self-update
   register: composer_update
   changed_when: '"You are already using composer" not in composer_update.stderr'

--- a/roles/dosomething.web/tasks/php-thirdparty.yml
+++ b/roles/dosomething.web/tasks/php-thirdparty.yml
@@ -2,28 +2,28 @@
 
 # New Relic
 - name: PHP Third Party | New Relic | Install repository
-  sudo: yes
+  become: yes
   apt_repository: repo="deb http://apt.newrelic.com/debian/ newrelic non-free"
   when: php_thirdparty_newrelic
 
 - name: PHP Third Party | New Relic | Install repository key
-  sudo: yes
+  become: yes
   apt_key: url=https://download.newrelic.com/548C16BF.gpg id=548C16BF
   when: php_thirdparty_newrelic
 
 - name: PHP Third Party | New Relic | Install PHP extension
-  sudo: yes
+  become: yes
   apt: name=newrelic-php5 state=latest force=yes
   notify: restart php-fpm
   when: php_thirdparty_newrelic
 
 - name: PHP Third Party | New Relic | Install New Relic server agent
-  sudo: yes
+  become: yes
   apt: name=newrelic-sysmond state=latest force=yes
   when: php_thirdparty_newrelic
 
 - name: PHP Third Party | New Relic | Setup New Relic Server Monitor License
-  sudo: yes
+  become: yes
   lineinfile: >
     dest=/etc/newrelic/nrsysmond.cfg
     regexp="^license_key"
@@ -32,7 +32,7 @@
   when: php_thirdparty_newrelic and php_thirdparty_newrelic_license
 
 - name: PHP Third Party | New Relic | Setup New Relic PHP Agent License
-  sudo: yes
+  become: yes
   lineinfile: >
     dest=/etc/php5/fpm/conf.d/20-newrelic.ini
     regexp="^newrelic.license"

--- a/roles/dosomething.web/tasks/php.yml
+++ b/roles/dosomething.web/tasks/php.yml
@@ -2,7 +2,7 @@
 
 - name: PHP | Install PHP
   apt: name={{ item }} state=latest
-  sudo: yes
+  become: yes
   with_items:
     - php5
     - php5-fpm
@@ -10,12 +10,12 @@
 
 - name: PHP | Install extensions
   apt: name={{ item }} state=latest
-  sudo: yes
+  become: yes
   with_items: "{{ php_extensions_defaults }} + {{ php_extensions }}"
   notify: restart php-fpm
 
 - name: PHP | Alter php.ini
-  sudo: yes
+  become: yes
   ini_file: >
     dest=/etc/php5/fpm/php.ini
     section={{ item.section }}
@@ -26,7 +26,7 @@
   notify: restart php-fpm
 
 - name: PHP | Setup FPM pool
-  sudo: yes
+  become: yes
   ini_file: >
     dest=/etc/php5/fpm/pool.d/www.conf
     section=www

--- a/roles/dosomething.web/tasks/web-server.yml
+++ b/roles/dosomething.web/tasks/web-server.yml
@@ -2,9 +2,9 @@
 
 - name: Install Web Server nginx
   apt: name=nginx state=latest
-  sudo: yes
+  become: yes
 
 - name: Nginx | Disable default vhost
-  sudo: yes
+  become: yes
   file: path=/etc/nginx/sites-enabled/default state=absent
   notify: restart nginx

--- a/thor-webapp.yml
+++ b/thor-webapp.yml
@@ -9,10 +9,10 @@
 #  hosts: tag_Role_Thor_WebApp
 #  tasks:
 #  - name: Install nfs-common
-#    sudo: yes
+#    become: yes
 #    apt: name=nfs-common state=latest
 #  - name: Mount NFS
-#    sudo: yes
+#    become: yes
 #    mount: >
 #      name=/var/www/www.dosomething.org/shared/files
 #      src='172.20.100.20:/drupal-static-files'


### PR DESCRIPTION
Fixes `become` deprecation warning:

```
[DEPRECATION WARNING]: Instead of sudo/sudo_user, use become/become_user and
make sure become_method is 'sudo' (default). This feature will be removed in a
future release. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
```