### PR TITLE
Fixes warning "Using bare variables is deprecated".

### DIFF
--- a/roles/dosomething.base/tasks/setup-devops-users.yml
+++ b/roles/dosomething.base/tasks/setup-devops-users.yml
@@ -5,7 +5,7 @@
   user: >
     name={{ item }}
     shell=/bin/bash
-  with_items: devops_users
+  with_items: "{{ devops_users }}"
 
 - name: SSH | Install public keys
   become: yes

--- a/roles/dosomething.db/tasks/main.yml
+++ b/roles/dosomething.db/tasks/main.yml
@@ -12,5 +12,5 @@
     option={{ item.option }}
     value={{ item.value }}
     backup=yes
-  with_items: my_cnf_settings
+  with_items: "{{ my_cnf_settings }}"
   notify: restart mysql

--- a/roles/dosomething.mb-node/tasks/apps.yml
+++ b/roles/dosomething.mb-node/tasks/apps.yml
@@ -13,12 +13,12 @@
     repo={{ item.repo }}
     version="{{ item.version | default(omit) }}"
     dest={{ mb_node_root }}/{{ item.name }}
-  with_items: mb_node_apps
+  with_items: "{{ mb_node_apps }}"
 
 - name: MB Node | Install Apps
   remote_user: "{{ app_user }}"
   npm: path={{ mb_node_root }}/{{ item.name }}
-  with_items: mb_node_apps
+  with_items: "{{ mb_node_apps }}"
 
 - name: MB Node | Configure Apps | Create config folder
   remote_user: "{{ app_user }}"
@@ -26,23 +26,23 @@
     path={{ mb_node_root }}/{{ item.name }}/config
     state=directory
     owner={{ app_user }}
-  with_items: mb_node_apps
+  with_items: "{{ mb_node_apps }}"
 
 - name: MB Node | Configure Apps | Copy mb_config
   remote_user: "{{ app_user }}"
   template: >
     src={{ item.name }}/mb_config.json.j2
     dest={{ mb_node_root }}/{{ item.name }}/config/mb_config.json
-  with_items: mb_node_apps
+  with_items: "{{ mb_node_apps }}"
 
 - name: MB Node | Configure Apps | Copy PM2 configuration
   remote_user: "{{ app_user }}"
   template: >
     src={{ item.name }}/pm2.json.j2
     dest={{ mb_node_root }}/{{ item.name }}/config/pm2.json
-  with_items: mb_node_apps
+  with_items: "{{ mb_node_apps }}"
 
 - name: MB Node | Configure Apps | Start Apps
   remote_user: "{{ app_user }}"
   command: pm2 start {{ mb_node_root }}/{{ item.name }}/config/pm2.json
-  with_items: mb_node_apps
+  with_items: "{{ mb_node_apps }}"

--- a/roles/dosomething.mb-php/tasks/apps.yml
+++ b/roles/dosomething.mb-php/tasks/apps.yml
@@ -26,7 +26,7 @@
     repo={{ item.repo }}
     version="{{ item.version | default(omit) }}"
     dest={{ mb_php_root }}/{{ item.name }}
-  with_items: mb_php_apps
+  with_items: "{{ mb_php_apps }}"
 
 - name: MB PHP | Create app log folders
   remote_user: "{{ app_user }}"
@@ -34,12 +34,12 @@
     path={{ mb_php_log_path }}/{{ item.name }}
     state=directory
     owner={{ app_user }}
-  with_items: mb_php_apps
+  with_items: "{{ mb_php_apps }}"
 
 - name: MB PHP | Install Composer Dependencies
   remote_user: "{{ app_user }}"
   composer: command=install working_dir={{ mb_php_root }}/{{ item.name }}
-  with_items: mb_php_apps
+  with_items: "{{ mb_php_apps }}"
   when: item.composer is not defined or item.composer
 
 - name: MB PHP | Configure Apps
@@ -50,18 +50,18 @@
     state=link
     owner={{ app_user }}
     group={{ app_user }}
-  with_items: mb_php_apps
+  with_items: "{{ mb_php_apps }}"
 
 - name: MB PHP | Install App Startup Sripts
   become: yes
   template: >
     src={{ item.name }}/init.conf.j2
     dest=/etc/init/{{ item.name }}.conf
-  with_items: mb_php_apps
+  with_items: "{{ mb_php_apps }}"
   when: item.init is not defined or item.init
 
 - name: MB PHP | Start apps
   become: yes
   service: name={{ item.name }} state=started
-  with_items: mb_php_apps
+  with_items: "{{ mb_php_apps }}"
   when: item.init is not defined or item.init

--- a/roles/dosomething.phoenix/tasks/configure-env.yml
+++ b/roles/dosomething.phoenix/tasks/configure-env.yml
@@ -7,7 +7,7 @@
     section=www
     option=env[{{ item.option }}]
     value={{ item.value }}
-  with_items: app_environment_variables
+  with_items: "{{ app_environment_variables }}"
   notify: restart php-fpm
 
 - name: Environment | Setup Shell Environment
@@ -16,4 +16,4 @@
     create=yes
     dest=/etc/profile.d/{{ app_user }}.sh
     line="export {{ item.option }}={{ item.value }}"
-  with_items: app_environment_variables
+  with_items: "{{ app_environment_variables }}"

--- a/roles/dosomething.php/tasks/php.yml
+++ b/roles/dosomething.php/tasks/php.yml
@@ -24,7 +24,7 @@
     option={{ item.option }}
     value={{ item.value }}
     backup=yes
-  with_items: php_ini_settings
+  with_items: "{{ php_ini_settings }}"
   notify: restart php-fpm
 
 - name: PHP | Setup FPM pool

--- a/roles/dosomething.rabbitmq/tasks/configure.yml
+++ b/roles/dosomething.rabbitmq/tasks/configure.yml
@@ -18,7 +18,7 @@
 - name: RabbitMQ | Create vhosts
   become: yes
   rabbitmq_vhost: name="{{ item }}"
-  with_items: rabbitmq_vhosts
+  with_items: "{{ rabbitmq_vhosts }}"
 
 - name: RabbitMQ | Create users
   become: yes
@@ -31,5 +31,5 @@
     read_priv:      "{{ item.0.read_priv | default('.*') }}"
     write_priv:     "{{ item.0.write_priv | default('.*') }}"
   with_subelements:
-    - rabbitmq_users
-    - vhosts
+    - "{{ rabbitmq_users }}"
+    - "{{ vhosts }}"

--- a/roles/dosomething.rabbitmq/tasks/install.yml
+++ b/roles/dosomething.rabbitmq/tasks/install.yml
@@ -17,5 +17,5 @@
 - name: RabbitMQ | Install plugins
   become: yes
   rabbitmq_plugin: names="{{ item }}"
-  with_items: rabbitmq_plugins
+  with_items: "{{ rabbitmq_plugins }}"
   notify: reload rabbitmq-server

--- a/roles/dosomething.search/tasks/solr-install-core.yml
+++ b/roles/dosomething.search/tasks/solr-install-core.yml
@@ -7,7 +7,7 @@
     repo={{ item.repo }}
     version={{ item.version }}
     dest=/var/solr/data/{{ item.name }}
-  with_items: solr_cores
+  with_items: "{{ solr_cores }}"
 
 - name: Enable default solr core
   become: yes
@@ -18,4 +18,4 @@
     -p {{ solr_port }}
   args:
     creates: /var/solr/data/{{ item.name }}/core.properties
-  with_items: solr_cores
+  with_items: "{{ solr_cores }}"

--- a/roles/dosomething.web/tasks/php.yml
+++ b/roles/dosomething.web/tasks/php.yml
@@ -22,7 +22,7 @@
     option={{ item.option }}
     value={{ item.value }}
     backup=yes
-  with_items: php_ini_settings
+  with_items: "{{ php_ini_settings }}"
   notify: restart php-fpm
 
 - name: PHP | Setup FPM pool


### PR DESCRIPTION
Fixes deprecation warning:

```
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your
playbooks so that the environment value uses the full variable syntax
('{{mb_php_apps}}'). This feature will be removed in a future release.
```