### PR TITLE
Fixes an error in `with_subelements`.

### DIFF
--- a/roles/dosomething.rabbitmq/tasks/configure.yml
+++ b/roles/dosomething.rabbitmq/tasks/configure.yml
@@ -32,4 +32,4 @@
     write_priv:     "{{ item.0.write_priv | default('.*') }}"
   with_subelements:
     - "{{ rabbitmq_users }}"
-    - "{{ vhosts }}"
+    - vhosts


### PR DESCRIPTION
Fixes an error introduced in #176. Second argument to `with_subelements` is a key, not variable.