### PR TITLE
Adding HA Proxy Server Setup for Quasar.

### DIFF
--- a/quasar-haproxy.yml
+++ b/quasar-haproxy.yml
@@ -1,0 +1,10 @@
+---
+
+- hosts: quasar-haproxy
+  gather_facts: yes
+  become: yes
+  vars:
+     servername: quasar-haproxy
+  roles:
+    - quasar.haproxy
+    - quasar-hosts

--- a/roles/quasar.haproxy/README.md
+++ b/roles/quasar.haproxy/README.md
@@ -1,0 +1,11 @@
+Quasar Environment HA-Proxy Install
+=========
+
+HA Proxy PPA install for latest stable version.
+Currently install HA Proxy 1.6 version.
+
+
+License
+-------
+
+MIT

--- a/roles/quasar.haproxy/meta/main.yml
+++ b/roles/quasar.haproxy/meta/main.yml
@@ -1,0 +1,14 @@
+---
+galaxy_info:
+  description: DoSomething.org Quasar Platform HA Proxy Setup
+  company: DoSomething.org
+  license: MIT
+  min_ansible_version: 2.0
+  platforms:
+  - name: Ubuntu
+    versions:
+    - xenial
+  categories:
+  - system
+dependencies:
+  - quasar.base

--- a/roles/quasar.haproxy/tasks/main.yml
+++ b/roles/quasar.haproxy/tasks/main.yml
@@ -1,0 +1,5 @@
+- name: Add HA Proxy PPA
+  apt_repository: repo='ppa:vbernat/haproxy-1.6' update_cache=yes state=present
+
+- name: Install HA Proxy
+  apt: name=haproxy state=present


### PR DESCRIPTION
#### What's this PR do?
Adds HA Proxy server install and playbook for Quasar environment.

#### Where should the reviewer start?
The quasar.haproxy role.

#### How should this be manually tested?
Already tested in Quasar AWS environment.


