### PR TITLE
Adding PostgreSQL connector for ETL nodes to connect to

### DIFF
--- a/roles/quasar.etl-node/tasks/main.yml
+++ b/roles/quasar.etl-node/tasks/main.yml
@@ -14,6 +14,7 @@
     - lxml
     - readline
     - sqlalchemy-redshift
+    - psycopg2
 
 ## The following has a dependency on the `base-os` role "appuser"
 #  being defined.


### PR DESCRIPTION
#### What's this PR do?

* Adds `psycopg2` PostgresSQL connector to Quasar ETL nodes.

#### Where should the reviewer start?

* The one line add below.

#### How should this be manually tested?

* Testing it LIVE!

#### Any background context you want to provide?

* We have the choice of SQL Alchemy Redshift or Psycopg2 to connect to PostgreSQL. Including both.