### PR TITLE
Adding PostgreSQL client to ETL nodes for bash scripts.

### DIFF
--- a/roles/quasar.etl-node/tasks/main.yml
+++ b/roles/quasar.etl-node/tasks/main.yml
@@ -4,6 +4,7 @@
     - python3-pip
     - libncurses5-dev
     - libpq-dev
+    - postgresql-client
 
 - name: Install Quasar ETL Pip Packages
   pip: name={{ item }} state=present executable=pip3


### PR DESCRIPTION
#### What's this PR do?

Adds PostgreSQL CLI client to ETL node role to allow bash scripting to RedShift.

#### Where should the reviewer start?

One line addition!

#### How should this be manually tested?

Already tested in Prod.


