### PR TITLE
Adding var check to Prod user.

### DIFF
--- a/roles/quasar.base/tasks/main.yml
+++ b/roles/quasar.base/tasks/main.yml
@@ -133,12 +133,14 @@
 - name: User Setup | Create Prod App User SSH Directory
   file: dest=/home/{{ item }}/.ssh owner={{ item }} group={{ item }} mode=750 state=directory
   with_items: "{{prod_users}}"
+  when: appuser is defined and appuser == "PROD"
 
 - name: User Setup | Setup Prod App User Public Key
   authorized_key:
      user={{ item }}
      key="{{ lookup('file', item + '-id_rsa.pub') }}"
   with_items: "{{prod_users}}"
+  when: appuser is defined and appuser == "PROD"
 
 ## Data Users
 # This section is for the DS Data team and only


### PR DESCRIPTION
#### What's this PR do?
Fixes a bug in Ansible Quuasar base role that doesn't take into account condition for Prod user existing after first creation task to create SSH dirs and keys.

#### Where should the reviewer start?
The two lines below!

#### How should this be manually tested?
Manually tested against Quasar box.


