### PR TITLE
Configure thor sixpack server using tags

### DIFF
--- a/thor-sixpack.yml
+++ b/thor-sixpack.yml
@@ -1,6 +1,6 @@
 ---
 
 - name: Setup Thor Sixpack Server
-  hosts: 172.20.100.38 # TODO(pnasrat) move to using Environment + Tag
+  hosts: tag_Environment_Thor:&tag_Role_Sixpack
   roles:
     - role: dosomething.sixpack


### PR DESCRIPTION
DoSomething/devops#246

#### What's this PR do?

Refactors new sixpack ansible configuration to use role sixpack server in thor env via tags. You can confirm my syntax via ansible command line

```
ansible -i /etc/ansible/ec2.py -m ping 'tag_Environment_Thor:&tag_Role_Sixpack' --list-hosts
  hosts (1):
    172.20.100.38
```
