### PR TITLE
Fix dependencies for ansible and sixpack

### DIFF
--- a/roles/dosomething.base/tasks/configure-system.yml
+++ b/roles/dosomething.base/tasks/configure-system.yml
@@ -1,5 +1,11 @@
 ---
 
+- name: "FIX: Ubuntu 16.04 LTS doesn't come with certain modules, required by ansible"
+  raw: apt-get install python-minimal aptitude -y
+  become: true
+  become_user: root
+  become_method: sudo
+
 - name: System | Check current timezone
   shell: cat /etc/timezone
   register: get_timezone

--- a/roles/dosomething.sixpack/tasks/main.yaml
+++ b/roles/dosomething.sixpack/tasks/main.yaml
@@ -14,13 +14,15 @@
 
 - name: Ensures sixpack directories exists
   become: yes
-  file: path=/etc/sixpack state=directory
   file:
-    path: /home/dosomething/sixpack
+    path: "{{ item }}"
     state: directory
     mode: 0755
     owner: dosomething
     group: dosomething
+  with_items:
+   - /etc/sixpack
+   - /home/dosomething/sixpack
 
 - name: Install Sixpack configuration
   become: yes
@@ -40,9 +42,9 @@
   with_items:
     - etc/nginx/conf.d/sixpack.conf
 
-- name: Enable gunicorn
+- name: Enable gunicorn and nginx
   become: yes
-  systemd:
-    name: gunicorn.socket
-    enabled: yes
-
+  service: name={{ item }} enabled=yes state=restarted
+  with_items:
+    - gunicorn
+    - nginx


### PR DESCRIPTION
Add a raw step to enable 16.04 builds from AMI/image to work.

Ensure systemd dependencies work for sixpack.

#### What's this PR do?
#### Where should the reviewer start?
#### How should this be manually tested?
I tested with vagrant destroy, the following vagrant changes to use 16.04 (and make it not use all memory on my laptop) and vagrant up - then curl localhost:8000 on the box.

```diff
diff --git a/Vagrantfile b/Vagrantfile
index afbb19e..cb5a0c5 100644
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,10 +1,10 @@
 Vagrant.configure("2") do |config|

   ## Choose your base box
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "bento/ubuntu-16.04"

   config.vm.provider "virtualbox" do |v|
-    v.customize ["modifyvm", :id, "--memory", 3072]
+    v.customize ["modifyvm", :id, "--memory", 2048]
     v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
   end

diff --git a/vagrant.yml b/vagrant.yml
index 080331d..9840402 100644
--- a/vagrant.yml
+++ b/vagrant.yml
@@ -3,4 +3,4 @@
 - name: Setup vagrant
   hosts: all
   roles:
-    - { role: dosomething.vagrant }
+    - { role: dosomething.sixpack }
```
