### PR TITLE
For vagrant builds only install sixpack on xenial

### DIFF
--- a/roles/dosomething.vagrant/meta/main.yml
+++ b/roles/dosomething.vagrant/meta/main.yml
@@ -20,4 +20,4 @@ dependencies:
   - { role: "dosomething.phoenix" }
   - { role: "dosomething.phoenix-dev" }
   - { role: "dosomething.rabbitmq" }
-  - { role: "dosomething.sixpack" }
+  - { role: "dosomething.sixpack", when: ansible_os_family == 'Ubuntu' and ansible_distribution_release == 'xenial' }


### PR DESCRIPTION
#### What's this PR do?

Allows local vagrant build to work by disabling sixpack on trusty.

We should discuss moving to 16.04 and what are the issues/concerns for that.

#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/13798/24370187/79b8f2d6-12f4-11e7-8eb9-dfde7fe43c0e.png)


#### Questions:
