### PR TITLE
Force remote user to be ubuntu for initial setup tasks

### DIFF
--- a/roles/dosomething.base/tasks/configure-system.yml
+++ b/roles/dosomething.base/tasks/configure-system.yml
@@ -2,36 +2,43 @@
 
 - name: "FIX: Ubuntu 16.04 LTS doesn't come with certain modules, required by ansible"
   raw: apt-get install python-minimal aptitude -y
+  remote_user: ubuntu
   become: true
   become_user: root
   become_method: sudo
 
 - name: System | Check current timezone
+  remote_user: ubuntu
   shell: cat /etc/timezone
   register: get_timezone
   changed_when: False
 
 - name: System | Set timezone
+  remote_user: ubuntu
   become: yes
   command: timedatectl set-timezone {{ timezone }}
   when: '"{{ timezone }}" not in get_timezone.stdout'
 
 - name: System | Ensure locale exists
+  remote_user: ubuntu  
   become: yes
   locale_gen: name={{ locale }} state=present
 
 - name: System | Check current locale
+  remote_user: ubuntu
   shell: cat /etc/default/locale
   register: get_locale
   changed_when: False
 
 - name: System | Set locale
+  remote_user: ubuntu
   become: yes
   command: update-locale LC_ALL={{ locale }} LANG={{ locale }}
   when: '"LC_ALL={{ locale }}" not in get_locale.stdout'
 
 # https://www.percona.com/blog/2014/04/28/oom-relation-vm-swappiness0-new-kernel/
 - name: System | Set vm.swappiness
+  remote_user: ubuntu
   become: yes
   sysctl: >
     name="vm.swappiness"

--- a/roles/dosomething.base/tasks/main.yml
+++ b/roles/dosomething.base/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 
 - include: configure-system.yml
+- include: setup-user.yml
 - include: update-system.yml
 - include: install-common-tools.yml
 - include: setup-ntp.yml
   when: ntp_servers
-- include: setup-user.yml
 - include: setup-devops-users.yml

--- a/roles/dosomething.base/tasks/setup-user.yml
+++ b/roles/dosomething.base/tasks/setup-user.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: Create the app user
+  remote_user: ubuntu
   become: yes
   user: >
     name={{ app_user }}
@@ -9,6 +10,7 @@
 
 - name: SSH | Install public keys
   become: yes
+  remote_user: ubuntu
   authorized_key: >
     user={{ app_user }}
     key="{{ lookup('file', 'files/app_user/ssh/authorized_keys') }}"


### PR DESCRIPTION
DoSomething/devops#246

#### What's this PR do?

Explicitly set remote user to be ubuntu (we probably can extract this) and setup base system config and app/deploy user.