### PR TITLE
Use tag to identify staging box

### DIFF
--- a/staging.yml
+++ b/staging.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Setup Staging Server
-  hosts: staging
+  hosts: tag_Name_Staging
   roles:
     - role: dosomething.web
     - role: dosomething.search


### PR DESCRIPTION
When trying to deploy @mirie ssh key to staging I noticed the ansible run succeeded but had no hosts

```
PLAYBOOK: staging.yml **********************************************************
1 plays in /var/lib/jenkins/jobs/Ansible Repo Checkout/workspace/staging.yml

PLAY [Setup Staging Server] ****************************************************
skipping: no hosts matched
```