### PR TITLE
Enable xdebug via symlink

### DIFF
--- a/roles/dosomething.phoenix-dev/tasks/xdebug.yml
+++ b/roles/dosomething.phoenix-dev/tasks/xdebug.yml
@@ -4,6 +4,13 @@
   become: yes
   apt: name=php-xdebug state=latest
 
+- name: Xdebug | enable
+  become: yes
+  file:
+    src: /etc/php7.1/mods-available/xdebug.ini
+    dest: /etc/php7.1/fpm/conf.d/20-xdebug.ini
+    state: link
+
 - name: Xdebug | Setup
   become: yes
   lineinfile: >


### PR DESCRIPTION
Error now due to ini file not being enabled. This should create the necessary link
